### PR TITLE
fixed error message spelling typo

### DIFF
--- a/kip/cli.py
+++ b/kip/cli.py
@@ -399,7 +399,7 @@ def copy_to_clipboard(msg):
         proc.communicate()
     except OSError as err:
         print('{} -- {}'.format(CLIP_CMD, err))
-        print('{} is propably not installed'.format(CLIP_CMD))
+        print('{} is probably not installed'.format(CLIP_CMD))
 
 
 def bold(msg):


### PR DESCRIPTION
Just a little user error message typo I spotted -- probably was misspelled as "propably".
