### PR TITLE
Better unicode handling in --notes " éà^e"

### DIFF
--- a/kip/cli.py
+++ b/kip/cli.py
@@ -67,7 +67,7 @@ Examples:
  Copies password (first line) to clipboard
  Echoes ebay username and notes (other lines)
 
- $ {name} add ebay.com --username graham_king "And some notes"
+ $ {name} add ebay.com --username graham_king --notes "And some notes"
  Generate random password (pwgen -s1 19)
  Creates file {home}ebay.com with format:
     pw


### PR DESCRIPTION
Everytime I use unicode char in --notes kip is raising an error out.
I don't think we need the unicode encoding/decoding dance in python 3 

Here it is a command that is causing issue : 

```
kip add yml_test --username 'yml' --notes "éàu"
```
